### PR TITLE
Feat location metaboxes

### DIFF
--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -236,36 +236,35 @@ function igv_cmb_metaboxes() {
 add_action( 'cmb2_admin_init', 'igv_location_taxonomy_metabox' );
 
 function igv_location_taxonomy_metabox() {
-	$prefix = '_igv_';
-	/**
-	 * Metabox to add fields to categories and tags
-	 */
-	$cmb_location = new_cmb2_box( array(
-		'id'               => $prefix . 'edit',
-		'title'            => esc_html__( 'Location Metabox', 'cmb2' ), // Doesn't output for term boxes
-		'object_types'     => array( 'term' ), // Tells CMB2 to use term_meta vs post_meta
-		'taxonomies'       => array( 'location', ), // Tells CMB2 which taxonomies should have these fields
-		// 'new_term_section' => true, // Will display in the "Add New Category" section
-	) );
+  $prefix = '_igv_';
+  /**
+   * Metabox to add fields to categories and tags
+   */
+  $cmb_location = new_cmb2_box(array(
+    'id'               => $prefix . 'edit',
+    'title'            => esc_html__('Location Metabox', 'cmb2'), // Doesn't output for term boxes
+    'object_types'     => array('term'), // Tells CMB2 to use term_meta vs post_meta
+    'taxonomies'       => array('location'), // Tells CMB2 which taxonomies should have these fields
+  ));
 
-	$cmb_location->add_field( array(
-		'name'     => esc_html__( 'Coordinates', 'cmb2' ),
-		'id'       => $prefix . 'location_coordinates',
-		'type'     => 'title',
-		'on_front' => false,
-	) );
+  $cmb_location->add_field(array(
+    'name'     => esc_html__('Coordinates', 'cmb2'),
+    'id'       => $prefix . 'location_coordinates',
+    'type'     => 'title',
+    'on_front' => false,
+  ));
 
-  $cmb_location->add_field( array(
-    'name' => esc_html__( 'Latitude', 'cmb2' ),
+  $cmb_location->add_field(array(
+    'name' => esc_html__('Latitude', 'cmb2'),
     'id'   => $prefix . 'location_lat',
     'type' => 'text',
-  ) );
+  ));
 
-  $cmb_location->add_field( array(
-    'name' => esc_html__( 'Longitude', 'cmb2' ),
+  $cmb_location->add_field(array(
+    'name' => esc_html__('Longitude', 'cmb2'),
     'id'   => $prefix . 'location_lon',
     'type' => 'text',
-  ) );
+  ));
 
 }
 ?>

--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -227,4 +227,45 @@ function igv_cmb_metaboxes() {
   }
 
 }
+
+
+
+/**
+ * Hook in and add a metabox to add fields to location taxonomies
+ */
+add_action( 'cmb2_admin_init', 'igv_location_taxonomy_metabox' );
+
+function igv_location_taxonomy_metabox() {
+	$prefix = '_igv_';
+	/**
+	 * Metabox to add fields to categories and tags
+	 */
+	$cmb_location = new_cmb2_box( array(
+		'id'               => $prefix . 'edit',
+		'title'            => esc_html__( 'Location Metabox', 'cmb2' ), // Doesn't output for term boxes
+		'object_types'     => array( 'term' ), // Tells CMB2 to use term_meta vs post_meta
+		'taxonomies'       => array( 'location', ), // Tells CMB2 which taxonomies should have these fields
+		// 'new_term_section' => true, // Will display in the "Add New Category" section
+	) );
+
+	$cmb_location->add_field( array(
+		'name'     => esc_html__( 'Coordinates', 'cmb2' ),
+		'id'       => $prefix . 'location_coordinates',
+		'type'     => 'title',
+		'on_front' => false,
+	) );
+
+  $cmb_location->add_field( array(
+    'name' => esc_html__( 'Latitude', 'cmb2' ),
+    'id'   => $prefix . 'location_lat',
+    'type' => 'text',
+  ) );
+
+  $cmb_location->add_field( array(
+    'name' => esc_html__( 'Longitude', 'cmb2' ),
+    'id'   => $prefix . 'location_lon',
+    'type' => 'text',
+  ) );
+
+}
 ?>

--- a/lib/meta-boxes.php
+++ b/lib/meta-boxes.php
@@ -252,6 +252,7 @@ function igv_location_taxonomy_metabox() {
     'id'       => $prefix . 'location_coordinates',
     'type'     => 'title',
     'on_front' => false,
+  	'desc'             => esc_html__( 'Set the geolocation in lat long values for this location. http://www.latlong.net/ can be helpful', 'cmb2' ),
   ));
 
   $cmb_location->add_field(array(


### PR DESCRIPTION
Adds 2 metaboxes to `location` taxonomy:
- Latitude
- Longitude

I tried with [mustardBees/cmb_field_map](https://github.com/mustardBees/cmb_field_map/) and [villeristi/CMB2-field-Leaflet-Geocoder](https://github.com/villeristi/CMB2-field-Leaflet-Geocoder) but neither worked.

I think this is fine at least for now.